### PR TITLE
Added some controls to the requests made

### DIFF
--- a/lib/cloudkick/commands/parallel.rb
+++ b/lib/cloudkick/commands/parallel.rb
@@ -28,7 +28,7 @@ module Cloudkick::Command
       file.flush
       begin
         if username
-          system("pssh --inline --timeout=-1  --hosts=#{file.path} --user=#{username} '#{command}'")
+          system("pssh --inline --timeout=-1 --hosts=#{file.path} --user=#{username} '#{command}'")
         else
           system("pssh --inline --timeout=-1 --hosts=#{file.path} '#{command}'")
         end

--- a/lib/cloudkick/node.rb
+++ b/lib/cloudkick/node.rb
@@ -16,14 +16,14 @@ require 'uri'
 
 module Cloudkick
 
-  class MalformedRequest < StandardError
-    def initialize (error)
+  class MalformedRequest < Exception
+    def initialize(error)
       self.message = "Malformed API query: #{error}"
     end 
   end
 
   class ConnectionError < Exception
-    def initialize (error_code, body)
+    def initialize(error_code, body)
       message = ""
       case error_code.to_i
         when 400 then message = "Bad Request"

--- a/lib/cloudkick/node.rb
+++ b/lib/cloudkick/node.rb
@@ -81,7 +81,7 @@ module Cloudkick
     #
     def check(type=nil)
      
-      if !type.match(/(mem|cpu|disk|plugin)(\/)([A-Za-z0-9\_\-\.]*)/)
+      if !type.match(/(mem|cpu|disk|plugin)(\/)?([A-Za-z0-9\_\-\.]*)?/)
         raise MalformedRequest.new("Unknown type #{type}")
       end
       

--- a/lib/cloudkick/node.rb
+++ b/lib/cloudkick/node.rb
@@ -16,9 +16,9 @@ require 'uri'
 
 module Cloudkick
 
-  class MalformedRequest < Exception
+  class MalformedRequest < StandardError
     def initialize(error)
-      self.message = "Malformed API query: #{error}"
+      raise self, "Malformed API query: #{error}"
     end 
   end
 
@@ -52,7 +52,7 @@ module Cloudkick
         when 505 then message = "HTTP Version Not Supported"
       end
 
-      self.message = "[#{error_code}] - #{message} (#{body})"
+      raise self, "[#{error_code}] - #{message} (#{body})"
     end
   end
   
@@ -82,7 +82,7 @@ module Cloudkick
     def check(type=nil)
      
       if !type.match(/(mem|cpu|disk|plugin)(\/)?([A-Za-z0-9\_\-\.]*)?/)
-        raise MalformedRequest.new("Unknown type #{type}")
+        raise MalformedRequest, "Unknown type #{type}"
       end
       
       resp, data = access_token.get("/1.0/query/node/#{@id}/check/#{type}")

--- a/lib/cloudkick/node.rb
+++ b/lib/cloudkick/node.rb
@@ -16,7 +16,7 @@ require 'uri'
 
 module Cloudkick
 
-  class MalformedRequest < StandardError
+  class MalformedRequest < Exception
     def initialize(error)
       raise self, "Malformed API query: #{error}"
     end 
@@ -24,35 +24,35 @@ module Cloudkick
 
   class ConnectionError < Exception
     def initialize(error_code, body)
-      message = ""
+      msg = ""
       case error_code.to_i
-        when 400 then message = "Bad Request"
-        when 401 then message = "Unauthorized"
-        when 402 then message = "Payment Required"
-        when 403 then message = "Forbidden"
-        when 404 then message = "Not Found"
-        when 405 then message = "Method not allowed"
-        when 406 then message = "Not Acceptable"
-        when 407 then message = "Proxy Authentication Required"
-        when 408 then message = "Request Timeout"
-        when 409 then message = "Conflict"
-        when 410 then message = "Gone"
-        when 411 then message = "Length Required"
-        when 412 then message = "Precondition Failed"
-        when 413 then message = "Request Entity Too Large"
-        when 414 then message = "Request-URI Too Long"
-        when 415 then message = "Unsupported Media Type"
-        when 416 then message = "Requested Range Not Satisfiable"
-        when 417 then message = "Expectation Failed"
-        when 500 then message = "Internal Server Error"
-        when 501 then message = "Not Implemented"
-        when 502 then message = "Bad Gateway"
-        when 503 then message = "Service Unavailable"
-        when 504 then message = "Gateway Timeout"
-        when 505 then message = "HTTP Version Not Supported"
+        when 400 then msg = "Bad Request"
+        when 401 then msg = "Unauthorized"
+        when 402 then msg = "Payment Required"
+        when 403 then msg = "Forbidden"
+        when 404 then msg = "Not Found"
+        when 405 then msg = "Method not allowed"
+        when 406 then msg = "Not Acceptable"
+        when 407 then msg = "Proxy Authentication Required"
+        when 408 then msg = "Request Timeout"
+        when 409 then msg = "Conflict"
+        when 410 then msg = "Gone"
+        when 411 then msg = "Length Required"
+        when 412 then msg = "Precondition Failed"
+        when 413 then msg = "Request Entity Too Large"
+        when 414 then msg = "Request-URI Too Long"
+        when 415 then msg = "Unsupported Media Type"
+        when 416 then msg = "Requested Range Not Satisfiable"
+        when 417 then msg = "Expectation Failed"
+        when 500 then msg = "Internal Server Error"
+        when 501 then msg = "Not Implemented"
+        when 502 then msg = "Bad Gateway"
+        when 503 then msg = "Service Unavailable"
+        when 504 then msg = "Gateway Timeout"
+        when 505 then msg = "HTTP Version Not Supported"
       end
 
-      raise self, "[#{error_code}] - #{message} (#{body})"
+      raise self, "[#{error_code}] - #{msg} (#{body})"
     end
   end
   


### PR DESCRIPTION
Hi,

I have added two major things to the requests made from Node class:
1. Control the types to be requested (through regular expression). This should be substituted with a call to the API asking for supported types and another call for a list of plugins (proposed to the API Cloudkick people)
2. Control the response code from the response. This way we launch an exception if there was an error instead of parsing with JSON the response body that is definetely not JSON valid.

They have filled a ticket (cloudkick team) for the (1) request. So probably within the next weeks we will be able to avoid the nasty regexp.

Joax.
